### PR TITLE
Update PGR global reset time

### DIFF
--- a/game-data.js
+++ b/game-data.js
@@ -1559,7 +1559,7 @@ var gameData = [
 		game: "Punishing: Gray Raven",
 		server: "Global",
 		timezone: "Etc/UTC",
-		dailyReset: "07:00",
+		dailyReset: "05:00",
 		icon: "punishing-gray-raven"
 	},
 	{


### PR DESCRIPTION
Since latest patch, reset time changed from 07:00 to 05:00.

Here is patch notes about it from https://grayravens.com:

> To accommodate upcoming events, the server reset time will be adjusted from 07:00 (UTC) to 05:00 (UTC), starting with the version Through the Tide Home. The following systems will be affected by this adjustment:
>
> - The reset time for Daily Missions will be adjusted to 05:00 (UTC) starting 2025/9/20.
> - The reset time for Weekly Missions will be adjusted to 05:00 (UTC) starting 2025/9/22.
> - The end time for [War Zone] will be adjusted to 05:00 (UTC) starting 2025/9/22.
> - The end time for [Phantom Pain Cage] will be adjusted to 05:00 (UTC) starting 2025/9/22
>
> https://grayravens.com/wiki/Through_The_Tide_Home#tabber-Patch_Notes

Close #734 